### PR TITLE
Generalize Angular plugin seed

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
         "@angular/platform-browser": "~17.3.6",
         "@angular/platform-browser-dynamic": "~17.3.6",
         "@angular/router": "17.3.6",
-        "@nativescript-community/template-snippet": "*",
         "@nativescript/angular": "~17.0.0",
         "@nativescript/core": "~8.7.2",
         "@nativescript/theme": "~3.0.2",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,7 +3,7 @@ import { Routes } from '@angular/router';
 import { NativeScriptRouterModule } from '@nativescript/angular';
 
 import { MenuComponent } from './menu/menu.component';
-import { demos } from '../../../demo-snippets/ng/install.module';
+import { demos } from './plugin/install.module';
 
 const demoRoutes = [];
 
@@ -11,7 +11,11 @@ for (const demo of demos) {
     demoRoutes.push({ path: demo.path, component: demo.component });
 }
 
-const routes: Routes = [{ path: '', redirectTo: '/menu', pathMatch: 'full' }, { path: 'menu', component: MenuComponent }, ...demoRoutes];
+const routes: Routes = [
+    { path: '', redirectTo: '/menu', pathMatch: 'full' },
+    { path: 'menu', component: MenuComponent },
+    ...demoRoutes
+];
 
 @NgModule({
     imports: [NativeScriptRouterModule.forRoot(routes)],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,21 +1,15 @@
 import { NO_ERRORS_SCHEMA, NgModule } from '@angular/core';
 import { NativeScriptModule } from '@nativescript/angular';
 
-import { InstallModule } from '../../../demo-snippets/ng/install.module';
-
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { MenuComponent } from './menu/menu.component';
-import { SimpleGridComponent } from '@nativescript-community/template-snippet/ng/simple-grid/simple-grid.component';
-import { HorizontalGridComponent } from '@nativescript-community/template-snippet/ng/horizontal-grid/horizontal-grid.component';
-import { SimpleWaterfallComponent } from '@nativescript-community/template-snippet/ng/simple-waterfall/simple-waterfall.component';
-import { SimpleTemplatesComponent } from '@nativescript-community/template-snippet/ng/simple-templates/simple-templates.component';
-import { SwipeMenuComponent } from '@nativescript-community/template-snippet/ng/swipe-menu/swipe-menu.component';
+import { COMPONENTS, InstallModule } from './plugin/install.module';
 
 @NgModule({
     bootstrap: [AppComponent],
     imports: [NativeScriptModule, AppRoutingModule, InstallModule],
-    declarations: [AppComponent, MenuComponent, SimpleGridComponent, HorizontalGridComponent, SimpleWaterfallComponent, SimpleTemplatesComponent, SwipeMenuComponent],
+    declarations: [AppComponent, MenuComponent, ...COMPONENTS],
     providers: [],
     schemas: [NO_ERRORS_SCHEMA]
 })

--- a/src/app/menu/menu.component.ts
+++ b/src/app/menu/menu.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { RouterExtensions } from '@nativescript/angular';
-import { demos } from '../../../../demo-snippets/ng/install.module';
+import { demos } from '../plugin/install.module';
 
 @Component({
     selector: 'ns-menu',

--- a/src/app/plugin/default/default.component.html
+++ b/src/app/plugin/default/default.component.html
@@ -1,0 +1,4 @@
+<ActionBar title="Default Angular template"> </ActionBar>
+<GridLayout margin="20">
+  <Label textWrap="true" style="font-size: 40;" text="This is just a placeholder component for the plugin seed, when the plugin code is built this component will get replaced by the components within the plugin library itself."></Label>
+</GridLayout>

--- a/src/app/plugin/default/default.component.ts
+++ b/src/app/plugin/default/default.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'ns-default',
+  templateUrl: './default.component.html',
+})
+export class DefaultComponent { }

--- a/src/app/plugin/install.module.ts
+++ b/src/app/plugin/install.module.ts
@@ -1,0 +1,14 @@
+import { NO_ERRORS_SCHEMA, NgModule } from '@angular/core';
+import { DefaultComponent } from './default/default.component';
+
+export const COMPONENTS = [DefaultComponent];
+@NgModule({
+    schemas: [NO_ERRORS_SCHEMA]
+})
+export class InstallModule {}
+
+export function installPlugin() { }
+
+export const demos = [
+    { name: 'Default', path: 'default', component: DefaultComponent }
+];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { platformNativeScript, runNativeScriptAngularApp } from '@nativescript/angular';
 import { AppModule } from './app/app.module';
+import { installPlugin } from './app/plugin/install.module';
 
-import { installPlugin } from '@nativescript-community/template-snippet/ng/install.module';
 installPlugin();
 
 runNativeScriptAngularApp({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "target": "es2017",
+        "target": "ES2020",
         "moduleResolution": "node",
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
         "skipLibCheck": true,
-        "lib": ["es2017", "dom"],
+        "lib": ["ESNext", "dom"],
         "baseUrl": ".",
         "paths": {
-            "*": ["node_modules/*"],
             "~/*": ["src/*"],
             "@/*": ["src/*"]
         }
     },
-    "include": ["./src/**/*", "./references.d.ts", "../demo-snippets/ng"],
+    "include": ["src/**/*"],
+    "files": ["./references.d.ts"],
     "exclude": ["node_modules", "platforms", "e2e"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,13 @@ if (fs.existsSync('../demo-snippets/webpack.config.ng.js')) {
 }
 
 module.exports = (env) => {
+    if (fs.existsSync('../demo-snippets/ng')) {
+        webpack.Utils.addCopyRule({
+            from: '../demo-snippets/ng',
+            to: webpack.Utils.project.getProjectRootPath() + '/src/app/plugin'
+        });
+    }
+
     if (fs.existsSync('../demo-snippets/assets')) {
         webpack.Utils.addCopyRule({
             from: '../demo-snippets/assets',


### PR DESCRIPTION
Allow the Angular plugin seed to be generic so that it can be reused by other plugins within the nativescript-community repo.